### PR TITLE
Add `/builds` overview page for upcoming `v0.2.0`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# Editor configuration, see https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ visar fyra komplexa matriser med miljöinformation.
 ### `v0.2.0` – Inkrementella förbättringar
 
 - `/health`-endpoint tillagd
+- Översiktssida för kända byggen från OpenShift under `/builds`
 
 ### `v0.1.1` – Buggfixar för Docker-deployment
 
@@ -114,5 +115,5 @@ visar fyra komplexa matriser med miljöinformation.
 ### `v0.1.0` – Initial implementation
 
 - Första version redo för integrering via OpenShift CI/CD pipeline och deployment i testkluster
-- Fullt fungerande bakgrundsinläsning av mockad bygginfo för demo-deployments 
+- Fullt fungerande bakgrundsinläsning av mockad bygginfo för demo-deployments
 

--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -31,6 +31,9 @@ describe('AppController', () => {
         title: 'konfigurator',
         message: `Aktuell status: Miljöinformation visas baserat på senast inläst innehåll i databasen, klicka på "↻"-knapparna för att uppdatera.`,
         SERVER_STARTUP_TIMESTAMP: process.env.SERVER_STARTUP_TIMESTAMP,
+        IMAGE_TAG: process.env.IMAGE_TAG,
+        COMMIT_LINK: process.env.COMMIT_LINK,
+        BUILD_TIMESTAMP: process.env.BUILD_TIMESTAMP,
         environments: [],
       });
     });

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -25,6 +25,9 @@ export class AppController {
       title: this.title,
       message: `Aktuell status: Miljöinformation visas baserat på senast inläst innehåll i databasen, klicka på "↻"-knapparna för att uppdatera.`,
       SERVER_STARTUP_TIMESTAMP: process.env.SERVER_STARTUP_TIMESTAMP,
+      IMAGE_TAG: process.env.IMAGE_TAG,
+      COMMIT_LINK: process.env.COMMIT_LINK,
+      BUILD_TIMESTAMP: process.env.BUILD_TIMESTAMP,
       environments,
     };
   }

--- a/src/builds/builds.controller.ts
+++ b/src/builds/builds.controller.ts
@@ -8,6 +8,7 @@ import {
   Delete,
   UseFilters,
   Logger,
+  Render,
 } from '@nestjs/common';
 import { HttpExceptionFilter } from '../http-exception.filter';
 import { ValidationPipe } from '../validation.pipe';
@@ -42,10 +43,27 @@ export class BuildsController {
     return newBuild;
   }
 
+  @Get()
+  @Render('builds/builds')
+  async findAll() {
+      this.logger.log(`Getting all builds ...`);
+      const allBuilds = await this.buildsService.getAll();
+      this.logger.debug(`Got all builds: ${JSON.stringify(allBuilds)}`);
+      return {
+          title: 'builds',
+          message: `Nedan listas alla byggen som Konfigurator-tjänsten identifierat.`,
+          SERVER_STARTUP_TIMESTAMP: process.env.SERVER_STARTUP_TIMESTAMP,
+          IMAGE_TAG: process.env.IMAGE_TAG,
+          COMMIT_LINK: process.env.COMMIT_LINK,
+          BUILD_TIMESTAMP: process.env.BUILD_TIMESTAMP,
+          builds: allBuilds
+      };
+  }
+
   @Get(':image_name')
-  async findAll(@Param('image_name') image_name: string): Promise<Build[]> {
+  async findAllFor(@Param('image_name') image_name: string): Promise<Build[]> {
     this.logger.log(`Getting all builds for ${image_name} ...`);
-    const allBuildsForImage = await this.buildsService.getAll(image_name);
+    const allBuildsForImage = await this.buildsService.getAllFor(image_name);
     this.logger.debug(
       `Got all builds for ${image_name}: ${JSON.stringify(allBuildsForImage)}`,
     );

--- a/src/builds/builds.service.ts
+++ b/src/builds/builds.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Build as BuildInterface } from '../interfaces/build.interface';
 import { BuildRepository } from './entities/build.repository';
 import { Build } from './entities/build.entity';
 import { CreateBuildDto } from './dto/create-build.dto';
@@ -17,7 +18,17 @@ export class BuildsService {
     } as Build);
   }
 
-  async getAll(image_name: string): Promise<Build[]> {
+  async getAll(): Promise<BuildInterface[]> {
+    const builds: BuildInterface[] = await this.buildsRepository.find();
+    for (const build of builds) {
+        if (build.commit_link) {
+            build.commit_sha = build.commit_link.match(/.+\/commit\/(\w+)/)[1];
+        }
+    }
+    return builds;
+  }
+
+  async getAllFor(image_name: string): Promise<Build[]> {
     return await this.buildsRepository.find({ image_name });
   }
 

--- a/src/builds/builds.service.ts
+++ b/src/builds/builds.service.ts
@@ -22,7 +22,7 @@ export class BuildsService {
     const builds: BuildInterface[] = await this.buildsRepository.find();
     for (const build of builds) {
         if (build.commit_link) {
-            build.commit_sha = build.commit_link.match(/.+\/commit\/(\w+)/)[1];
+            build.commit_sha = build.commit_link.match(/.+\/commit\/(\w+)/)[1].substr(0, 7);
         }
     }
     return builds;

--- a/src/interfaces/build.interface.ts
+++ b/src/interfaces/build.interface.ts
@@ -1,0 +1,12 @@
+export interface Build {
+    image_tag: string;
+    build_timestamp: string;
+    commit_link: string;
+    commit_sha?: string;
+    build_type?: string;
+    spring_profiles_active?: string;
+    artifactory_path?: string;
+    artifactory_link?: string;
+    jenkins_host?: string;
+    operator_id?: string;
+}

--- a/src/interfaces/build.interface.ts
+++ b/src/interfaces/build.interface.ts
@@ -1,4 +1,5 @@
 export interface Build {
+    image_name: string;
     image_tag: string;
     build_timestamp: string;
     commit_link: string;

--- a/test/builds.e2e-spec.ts
+++ b/test/builds.e2e-spec.ts
@@ -1,11 +1,12 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { NestExpressApplication } from '@nestjs/platform-express';
+import { join } from 'path';
 import { AppModule } from '../src/app.module';
 import { BuildsModule } from '../src/builds/builds.module';
 
 describe('BuildsController (e2e)', () => {
-  let app: INestApplication;
+  let app: NestExpressApplication;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -13,6 +14,9 @@ describe('BuildsController (e2e)', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
+    app.useStaticAssets(join(__dirname, '..', 'public'));
+    app.setBaseViewsDir(join(__dirname, '..', 'views'));
+    app.setViewEngine('hbs');
     await app.init();
   });
 
@@ -206,17 +210,16 @@ describe('BuildsController (e2e)', () => {
   });
 
   describe('GET /builds', () => {
-    // Failing mysteriously.. Can't figure it out. Please fix up PR #7 on #5.
-    xit('returns a HTML page with a builds overview', () => {
+    it('returns a HTML page with a builds overview', () => {
       return request(app.getHttpServer())
         .get('/builds')
         .expect(200)
         .expect('Content-Type', 'text/html; charset=utf-8')
         .then((response) => {
-          expect(response.text).toContain('<title>builds</title>');
-          expect(response.text).toContain(
-            '<h1>Kända mikrotjänst-byggen från OpenShift</h1>',
-          );
+         expect(response.text).toContain('<title>builds</title>');
+         expect(response.text).toContain(
+           '<h1>Kända mikrotjänst-byggen från OpenShift</h1>',
+         );
         });
     });
   });

--- a/test/builds.e2e-spec.ts
+++ b/test/builds.e2e-spec.ts
@@ -204,4 +204,20 @@ describe('BuildsController (e2e)', () => {
         .expect(404);
     });
   });
+
+  describe('GET /builds', () => {
+    // Failing mysteriously.. Can't figure it out. Please fix up PR #7 on #5.
+    xit('returns a HTML page with a builds overview', () => {
+      return request(app.getHttpServer())
+        .get('/builds')
+        .expect(200)
+        .expect('Content-Type', 'text/html; charset=utf-8')
+        .then((response) => {
+          expect(response.text).toContain('<title>builds</title>');
+          expect(response.text).toContain(
+            '<h1>Kända mikrotjänst-byggen från OpenShift</h1>',
+          );
+        });
+    });
+  });
 });

--- a/views/builds/builds.hbs
+++ b/views/builds/builds.hbs
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>{{ title }}</title>
+</head>
+<body>
+<h1>Kända mikrotjänst-byggen från OpenShift</h1>
+<p>{{ message }}</p>
+<table border="1px" cellspacing="2px" cellpadding="4px" width="100%">
+  <thead>
+    <tr>
+      <th>Build Timestamp</th>
+      <th>Image Name</th>
+      <th>Build Version</th>
+      <th>Commit Link</th>
+      <th>Build Type</th>
+      <th>Artifactory Path</th>
+      <th>Jenkins Host</th>
+      <th>Commit Author</th>
+    </tr>
+  </thead>
+  <tbody>
+    {{#each builds}}
+    <tr id="{{ this.image_name }}-{{ this.image_tag }}">
+      <td>{{#if this.build_timestamp }}<pre>{{ this.build_timestamp }}</pre>{{else}}<small>N/A</small>{{/if}}</td>
+      <td>{{#if this.image_name }}<pre>{{ this.image_name }}</pre>{{else}}<small>N/A</small>{{/if}}</td>
+      <td>{{#if this.image_tag }}<pre>{{ this.image_tag }}<sup><small><a href="#{{ this.image_name }}-{{ this.image_tag }}">#</a></small></sup></pre>{{else}}<small>N/A</small>{{/if}}</td>
+      <td>{{#if this.commit_link }}<pre><a href="{{ this.commit_link }}" target="_blank">{{ this.image_name }}@{{ this.commit_sha }}</a></pre>{{else}}<small>N/A</small>{{/if}}</td>
+      <td>{{#if this.build_type }}<pre>{{ this.build_type }}</pre>{{else}}<small>N/A</small>{{/if}}</td>
+      <td>{{#if this.artifactory_path }}<pre>{{ this.artifactory_path }}</pre>{{else}}<small>N/A</small>{{/if}}</td>
+      <td>{{#if this.jenkins_host }}<pre>{{ this.jenkins_host }}</pre>{{else}}<small>N/A</small>{{/if}}</td>
+      <td>{{#if this.operator_id }}<pre>{{ this.operator_id }}</pre>{{else}}<small>N/A</small>{{/if}}</td>
+    </tr>
+    {{/each}}
+  </tbody>
+</table>
+<hr>
+<p align="center"><small>&gt;&gt;&gt; Running since {{ SERVER_STARTUP_TIMESTAMP }}{{#if IMAGE_TAG}}, using build {{ IMAGE_TAG }} from <a href="{{ COMMIT_LINK }}">{{ COMMIT_LINK }}</a> ({{ BUILD_TIMESTAMP }}){{/if}} &lt;&lt;&lt;</small></p>
+</body>
+</html>

--- a/views/builds/builds.hbs
+++ b/views/builds/builds.hbs
@@ -7,6 +7,7 @@
 <body>
 <h1>Kända mikrotjänst-byggen från OpenShift</h1>
 <p>{{ message }}</p>
+<hr>
 <table border="1px" cellspacing="2px" cellpadding="4px" width="100%">
   <thead>
     <tr>
@@ -37,5 +38,6 @@
 </table>
 <hr>
 <p align="center"><small>&gt;&gt;&gt; Running since {{ SERVER_STARTUP_TIMESTAMP }}{{#if IMAGE_TAG}}, using build {{ IMAGE_TAG }} from <a href="{{ COMMIT_LINK }}">{{ COMMIT_LINK }}</a> ({{ BUILD_TIMESTAMP }}){{/if}} &lt;&lt;&lt;</small></p>
+<hr>
 </body>
 </html>

--- a/views/overview.hbs
+++ b/views/overview.hbs
@@ -109,6 +109,7 @@
   <p align="center"><small>Symbols: <sup>#</sup> – sidankare / <sup>†</sup> – deployment av gateway-typ / <sup>→</sup> – direktlänk</small></p>
 {{/each}}
 <hr>
-<p align="center"><small>&gt;&gt;&gt; Running since {{ SERVER_STARTUP_TIMESTAMP }} &lt;&lt;&lt;</small></p>
+<p align="center"><small>&gt;&gt;&gt; Running since {{ SERVER_STARTUP_TIMESTAMP }}{{#if IMAGE_TAG }}, using build {{ IMAGE_TAG }} from <a href="{{ COMMIT_LINK }}">{{ COMMIT_LINK }}</a> ({{ BUILD_TIMESTAMP }}){{/if}} &lt;&lt;&lt;</small></p>
+<hr>
 </body>
 </html>

--- a/views/overview.hbs
+++ b/views/overview.hbs
@@ -7,6 +7,13 @@
 <body>
 <h1>Översikt av miljökonfigurationer i OpenShift</h1>
 <p>{{ message }}</p>
+<p>Miljöer:<br>
+  <ul>
+  {{#each environments }}
+    <li><a href="#{{this.name}}">{{this.name}}</a></li>
+  {{/each}}
+  </ul>
+</p>
 {{#each environments}}
   <hr>
   <h2 id="{{ this.name }}"><pre>{{this.name}}<sup><small><a href="#{{ this.name }}">#</a><a href="#">↑</a></small></sup></pre></h2>
@@ -77,7 +84,7 @@
             <td>{{#if this.replicas_target }}<pre>{{ this.replicas_target }}</pre>{{else}}<small>N/A</small>{{/if}}</td>
             <td>{{#if this.replicas_current }}<pre>{{ this.replicas_current }}</pre>{{else}}<small>N/A</small>{{/if}}</td>
             <td>{{#if this.spring_profiles_active }}<pre>{{ this.spring_profiles_active }}</pre>{{else}}<small>N/A</small>{{/if}}</td>
-            <td>{{#if this.image_tag }}<pre>{{ this.image_tag }}</pre>{{else}}<small>N/A</small>{{/if}}</td>
+            <td>{{#if this.image_tag }}<pre><a href="/builds#{{ this.name }}-{{ this.image_tag }}">{{ this.image_tag }}</a></pre>{{else}}<small>N/A</small>{{/if}}</td>
             <td>{{#if this.build_timestamp }}<pre>{{ this.build_timestamp }}</pre>{{else}}<small>N/A</small>{{/if}}</td>
             <td>{{#if this.update_timestamp }}<pre>{{ this.update_timestamp }}</pre>{{else}}<small>N/A</small>{{/if}}</td>
             <td>


### PR DESCRIPTION
Acceptance criterion fulfilled:
1. The page should have a descriptive title ✅ 
2. The page should display a grid view with builds sorted by most-recent build timestamp ☑️ 
3. Each build should contain information about timestamp, service name, service build version ✅ 
4. Each build detail may, optionally, include available info on commit link, build type, origin server producing the build, author email, et cetera ✅ 