### PR TITLE
Finishing touches to `GET /tasks` ahead of `0.2.0` release

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ visar fyra komplexa matriser med miljöinformation.
 
 - `/health`-endpoint tillagd
 - Översiktssida för kända byggen från OpenShift under `/builds`
+- Översiktssida med Konfiguratorns historik av bakgrundsjobb under `/tasks`
 
 ### `v0.1.1` – Buggfixar för Docker-deployment
 

--- a/test/tasks.e2e-spec.ts
+++ b/test/tasks.e2e-spec.ts
@@ -1,0 +1,37 @@
+import * as request from 'supertest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { NestExpressApplication } from '@nestjs/platform-express';
+import { join } from 'path';
+import { AppModule } from '../src/app.module';
+import { TasksModule } from '../src/tasks/tasks.module';
+
+describe('TasksController (e2e)', () => {
+  let app: NestExpressApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule, TasksModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useStaticAssets(join(__dirname, '..', 'public'));
+    app.setBaseViewsDir(join(__dirname, '..', 'views'));
+    app.setViewEngine('hbs');
+    await app.init();
+  });
+
+  describe('GET /tasks', () => {
+    it('returns a HTML page with a tasks overview', () => {
+      return request(app.getHttpServer())
+        .get('/tasks')
+        .expect(200)
+        .expect('Content-Type', 'text/html; charset=utf-8')
+        .then((response) => {
+         expect(response.text).toContain('<title>tasks</title>');
+         expect(response.text).toContain(
+           '<h1>Översikt av bakgrundsjobb</h1>',
+         );
+        });
+    });
+  });
+});

--- a/views/builds/builds.hbs
+++ b/views/builds/builds.hbs
@@ -37,7 +37,7 @@
   </tbody>
 </table>
 <hr>
-<p align="center"><small>&gt;&gt;&gt; Running since {{ SERVER_STARTUP_TIMESTAMP }}{{#if IMAGE_TAG}}, using build {{ IMAGE_TAG }} from <a href="{{ COMMIT_LINK }}">{{ COMMIT_LINK }}</a> ({{ BUILD_TIMESTAMP }}){{/if}} &lt;&lt;&lt;</small></p>
+<p align="center"><small>&gt;&gt;&gt; Running since {{ SERVER_STARTUP_TIMESTAMP }}{{#if IMAGE_TAG }}, using build {{ IMAGE_TAG }} from <a href="{{ COMMIT_LINK }}">{{ COMMIT_LINK }}</a> ({{ BUILD_TIMESTAMP }}){{/if}} &lt;&lt;&lt;</small></p>
 <hr>
 </body>
 </html>

--- a/views/tasks/tasks.hbs
+++ b/views/tasks/tasks.hbs
@@ -5,7 +5,7 @@
   <title>{{ title }}</title>
 </head>
 <body>
-<h1>Kända bakgrundsjobb från OpenShift</h1>
+<h1>Översikt av bakgrundsjobb</h1>
 <p>{{ message }}</p>
 <hr>
 <table border="1px" cellspacing="2px" cellpadding="4px" width="100%">
@@ -19,7 +19,7 @@
     </tr>
   </thead>
   <tbody>
-    {{#each tasks}} 
+    {{#each tasks}}
     <tr id="{{ this.image_name }}-{{ this.image_tag }}">
       <td>{{#if this.id }}<pre>{{ this.id }}</pre>{{else}}<small>N/A</small>{{/if}}</td>
       <td>{{#if this.action }}<pre>{{ this.action }}</pre>{{else}}<small>N/A</small>{{/if}}</td>
@@ -31,7 +31,7 @@
   </tbody>
 </table>
 <hr>
-<p align="center"><small>&gt;&gt;&gt; Running since {{ SERVER_STARTUP_TIMESTAMP }}{{#if IMAGE_TAG}}, using build {{ IMAGE_TAG }} from <a href="{{ COMMIT_LINK }}">{{ COMMIT_LINK }}</a> ({{ BUILD_TIMESTAMP }}){{/if}} &lt;&lt;&lt;</small></p>
+<p align="center"><small>&gt;&gt;&gt; Running since {{ SERVER_STARTUP_TIMESTAMP }}{{#if IMAGE_TAG }}, using build {{ IMAGE_TAG }} from <a href="{{ COMMIT_LINK }}">{{ COMMIT_LINK }}</a> ({{ BUILD_TIMESTAMP }}){{/if}} &lt;&lt;&lt;</small></p>
 <hr>
 </body>
 </html>


### PR DESCRIPTION
- End-2-end test suite added, `TasksController (e2e)`
- A simple test case for the `/tasks` overview,
  `GET /tasks -> IT returs a HTML page with a tasks overview`
- Changelog update
- Wording, improved. :gem: