### PR TITLE
Fully automate dev setup with Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,4 @@
+image: node:12-alpine
+tasks:
+  - init: npm install && npm run build
+    command: npm run start:dev

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # `konfigurator` – Ordning och reda i OpenShift
 
-En webbtjänst för att spåra och rekonfigurera vad som körs i dina OpenShift-miljöer. [![Docker Repository on Quay](https://quay.io/repository/mkdevops/konfigurator/status "Docker Repository on Quay")](https://quay.io/repository/mkdevops/konfigurator)
+En webbtjänst för att spåra och rekonfigurera vad som körs i dina OpenShift-miljöer.
 
-[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/mkdevops-se/konfigurator)
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/mkdevops-se/konfigurator) [![Docker Repository on Quay](https://quay.io/repository/mkdevops/konfigurator/status "Docker Repository on Quay")](https://quay.io/repository/mkdevops/konfigurator)
 
 ## Ramverk
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 En webbtjänst för att spåra och rekonfigurera vad som körs i dina OpenShift-miljöer. [![Docker Repository on Quay](https://quay.io/repository/mkdevops/konfigurator/status "Docker Repository on Quay")](https://quay.io/repository/mkdevops/konfigurator)
 
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/mkdevops-se/konfigurator)
 
 ## Ramverk
 


### PR DESCRIPTION
This commit implements a fully-automated development setup using Gitpod.io, an
online IDE for GitLab, GitHub, and Bitbucket that enables Dev-Environments-As-Code.
This makes it easy for anyone to get a ready-to-code workspace for any branch,
issue or pull request almost instantly with a single click.

(Resolves #9.)