### PR TITLE
#22 Add `Joi` Library and Enable NestJS Config Validation

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -11,12 +11,12 @@ DATABASE_SYNCHRONIZE=true
 OAUTH2_ISSUER=https://mkdevops.eu.auth0.com/
 OAUTH2_AUDIENCE=urn:mkdevops:konfigurator
 OAUTH2_AUTH0_TENANT_DOMAIN=mkdevops.eu.auth0.com
-OAUTH2_AUTH0_CLIENT_ID=ZTu**************************H8V
-OAUTH2_AUTH0_CLIENT_SECRET=lxf**********************************************************nCT
+OAUTH2_AUTH0_CLIENT_ID=ZTu__________________________H8V
+OAUTH2_AUTH0_CLIENT_SECRET=lxf___________________________________________________-______nCT
 OAUTH2_AUTH0_CALLBACK_URL=http://localhost:3000/callback
-OAUTH2_SIGNING_SECRET=siW**************************xzQ
+OAUTH2_SIGNING_SECRET=siW__________________________xzQ
 OAUTH2_SIGNING_ALGORITHM=HS256
 OAUTH2_LOCAL_ACCESS_TOKEN=tmp/access_token.txt
 
 # Session
-SESSION_SECRET=xfI**************************f56
+SESSION_SECRET=xfI__________________________f56

--- a/.env.test
+++ b/.env.test
@@ -11,12 +11,12 @@ DATABASE_SYNCHRONIZE=true
 OAUTH2_ISSUER=https://mkdevops.eu.auth0.com/
 OAUTH2_AUDIENCE=urn:mkdevops:konfigurator
 OAUTH2_AUTH0_TENANT_DOMAIN=mkdevops.eu.auth0.com
-OAUTH2_AUTH0_CLIENT_ID=ZTu**************************H8V
-OAUTH2_AUTH0_CLIENT_SECRET=lxf**********************************************************nCT
+OAUTH2_AUTH0_CLIENT_ID=ZTu__________________________H8V
+OAUTH2_AUTH0_CLIENT_SECRET=lxf___________________________________________________-______nCT
 OAUTH2_AUTH0_CALLBACK_URL=http://localhost:3000/callback
-OAUTH2_SIGNING_SECRET=siW**************************xzQ
+OAUTH2_SIGNING_SECRET=siW__________________________xzQ
 OAUTH2_SIGNING_ALGORITHM=HS256
 OAUTH2_LOCAL_ACCESS_TOKEN=tmp/access_token.txt
 
 # Session
-SESSION_SECRET=xfI**************************f56
+SESSION_SECRET=xfI__________________________f56

--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,8 @@ lerna-debug.log*
 /tmp
 
 # Secrets
-.env
-.env.test
+.env.development
+.env.production
 docker-compose.yml
 
 # Prod runtime

--- a/README.md
+++ b/README.md
@@ -41,14 +41,13 @@ $ npm install
 ## Starta applikationen
 
 ```bash
-# development
-$ npm run start
+# create development env and start in watch mode
+$ cp -v .env.template .env.development
+$ NODE_ENV=development npm run start:dev
 
-# watch mode
-$ npm run start:dev
-
-# production mode
-$ npm run start:prod
+# create prod env and start in production mode
+$ cp -v .env.template .env.production
+$ NODE_ENV=production npm run start:prod
 ```
 
 ### Lokal demo-deployment
@@ -108,6 +107,7 @@ $ docker-compose up -d konfigurator
 - API-endpoints som tillhandahåller skriv-access begränsade till klienter med
   en giltig biljett i _`Authorization`_-headern eller en inloggad OpenID Connect-session med Auth0
 - README-instruktionen för _Lokal demo-deployment_ uppdaterad med nytt förfarande
+- Refaktorerad konfigurationshantering för utveckling och produktion
 
 ### `v0.2.0` – Inkrementella förbättringar
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,18 +4,12 @@ services:
   konfigurator:
     container_name: konfigurator
     image: quay.io/mkdevops/konfigurator
+    env_file:
+      - .env.production
     environment:
       - DATABASE_URL=/data/konfigurator.db
-      - OAUTH2_ISSUER=https://mkdevops.eu.auth0.com/
-      - OAUTH2_AUDIENCE=urn:mkdevops:konfigurator
-      - OAUTH2_AUTH0_TENANT_DOMAIN=mkdevops.eu.auth0.com
-      - OAUTH2_AUTH0_CLIENT_ID=ZTu**************************H8V
-      - OAUTH2_AUTH0_CLIENT_SECRET=lxf**********************************************************nCT
-      - OAUTH2_AUTH0_CALLBACK_URL=http://localhost:3000/callback
-      - OAUTH2_SIGNING_SECRET=siW**************************xzQ
-      - OAUTH2_SIGNING_ALGORITHM=HS256
-      - OAUTH2_LOCAL_ACCESS_TOKEN=tmp/access_token.txt
-      - SESSION_SECRET=xfI**************************f56
+      - OAUTH2_AUTH0_CALLBACK_URL=https://konfigurator.mkdevops.se/callback
+      - OAUTH2_LOCAL_ACCESS_TOKEN=/tmp/access_token.txt
     ports:
       - "3000:3000"
     volumes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -471,6 +471,19 @@
         "strip-json-comments": "^3.1.1"
       }
     },
+    "@hapi/hoek": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
+      "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
+    },
+    "@hapi/topo": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+      "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1032,6 +1045,24 @@
         "@angular-devkit/core": "11.0.3",
         "@angular-devkit/schematics": "11.0.3"
       }
+    },
+    "@sideway/address": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.1.tgz",
+      "integrity": "sha512-+I5aaQr3m0OAmMr7RQ3fR9zx55sejEYR2BFJaxL+zT3VM2611X0SHvPWIbAUBZVTn/YzYKbV8gJ2oT/QELknfQ==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "@sinonjs/commons": {
       "version": "1.8.1",
@@ -5226,6 +5257,18 @@
         "@types/node": "*",
         "merge-stream": "^2.0.0",
         "supports-color": "^7.0.0"
+      }
+    },
+    "joi": {
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.0.tgz",
+      "integrity": "sha512-F4WiW2xaV6wc1jxete70Rw4V/VuMd6IN+a5ilZsxG4uYtUXWu2kq9W5P2dz30e7Gmw8RCbY/u/uk+dMPma9tAg==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.0",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
       }
     },
     "js-tokens": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "express-handlebars": "^5.2.1",
     "express-session": "^1.17.1",
     "hbs": "^4.1.1",
+    "joi": "^17.4.0",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.20",
     "passport": "^0.4.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,3 +1,4 @@
+import * as Joi from 'joi';
 import { APP_GUARD } from '@nestjs/core';
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
@@ -27,9 +28,35 @@ import { AuthenticatedGuard } from './common/guards/authenticated.guard';
     TerminusModule,
     ConfigModule.forRoot({
       isGlobal: true,
-      envFilePath: `.env${
-        process.env.NODE_ENV ? '.' + process.env.NODE_ENV : ''
-      }`,
+      validationSchema: Joi.object({
+        NODE_ENV: Joi.string()
+          .valid('development', 'test', 'production')
+          .default('development'),
+        WEB_SERVER_PORT: Joi.number().default('3000'),
+        WEB_SERVER_HOST: Joi.string().hostname().default('localhost'),
+        DATABASE_URL: Joi.string().uri({ allowRelative: true }).required(),
+        DATABASE_DROP_SCHEMA: Joi.alternatives('true', 'false').default(
+          'false',
+        ),
+        DATABASE_SYNCHRONIZE: Joi.alternatives('true', 'false').default('true'),
+        OAUTH2_ISSUER: Joi.string().uri().required(),
+        OAUTH2_AUDIENCE: Joi.string()
+          .regex(/[a-z\-\/.]+/)
+          .required(),
+        OAUTH2_AUTH0_TENANT_DOMAIN: Joi.string().hostname().required(),
+        OAUTH2_AUTH0_CLIENT_ID: Joi.string().token().required(),
+        OAUTH2_AUTH0_CLIENT_SECRET: Joi.string()
+          .regex(/[a-zA-Z\-]+/)
+          .required(),
+        OAUTH2_AUTH0_CALLBACK_URL: Joi.string().uri().required(),
+        OAUTH2_SIGNING_SECRET: Joi.string().token().required(),
+        OAUTH2_SIGNING_ALGORITHM: Joi.string().valid('HS256').default('HS256'),
+        OAUTH2_LOCAL_ACCESS_TOKEN: Joi.string()
+          .uri({ allowRelative: true })
+          .required(),
+        SESSION_SECRET: Joi.string().token(),
+      }),
+      envFilePath: `.env.${process.env.NODE_ENV}`,
       expandVariables: true,
     }),
     ScheduleModule.forRoot(),

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,8 +34,8 @@ async function bootstrap() {
   app.use(flash());
 
   await app.listen(
-    +configService.get<string>('WEB_SERVER_PORT', '3000'),
-    configService.get<string>('WEB_SERVER_HOST', 'localhost'),
+    +configService.get<string>('WEB_SERVER_PORT'),
+    configService.get<string>('WEB_SERVER_HOST'),
   );
 }
 bootstrap();


### PR DESCRIPTION
- `.env -> .env.template`, usable for copying the standard environment config into a `.GITIGNORE`'d `.env.development` for dev and a `.env.production` for prod
- `npm install --save joi` + added a validation schema for all environment variables in use (following https://docs.nestjs.com/techniques/configuration guide)
- README instructions updated with new approach to getting started