### PR TITLE
#31 UI Clean-Up + Editable Environment Comment

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,3 +1,6 @@
+# Node Interpreter
+NODE_ICU_DATA=./node_modules/full-icu
+
 # Web Server Host and Port
 WEB_SERVER_HOST=0.0.0.0
 WEB_SERVER_PORT=3000

--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,6 @@
+# Node Interpreter
+NODE_ICU_DATA=./node_modules/full-icu
+
 # Web Server Host and Port
 WEB_SERVER_HOST=0.0.0.0
 WEB_SERVER_PORT=3000

--- a/.envrc
+++ b/.envrc
@@ -3,4 +3,6 @@ tools_stack="
   node-v12
 "
 
+export NODE_ICU_DATA=./node_modules/full-icu
+
 command -v setup_ocp_tools_stack &> /dev/null && setup_ocp_tools_stack

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
+  "endOfLine": "auto",
   "singleQuote": true,
   "trailingComma": "all"
 }

--- a/.s2i/environment
+++ b/.s2i/environment
@@ -1,1 +1,4 @@
-../.env
+NODE_ICU_DATA=./node_modules/full-icu
+
+WEB_SERVER_HOST=0.0.0.0
+WEB_SERVER_PORT=3000

--- a/.s2i/environment
+++ b/.s2i/environment
@@ -1,4 +1,4 @@
-NODE_ICU_DATA=./node_modules/full-icu
+#NODE_ICU_DATA=./node_modules/full-icu
 
 WEB_SERVER_HOST=0.0.0.0
 WEB_SERVER_PORT=3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
 FROM quay.io/centos7/nodejs-12-centos7
 LABEL "io.openshift.s2i.scripts-url"="image:///usr/libexec/s2i" \
       "io.openshift.s2i.build.image"="quay.io/centos7/nodejs-12-centos7"
-ENV WEB_SERVER_HOST="0.0.0.0" \
-    WEB_SERVER_PORT="3000" \
-    DATABASE_URL="tmp/konfigurator.db" \
-    DATABASE_DROP_SCHEMA="false" \
-    DATABASE_SYNCHRONIZE="true"
+ENV NODE_ICU_DATA="node_modules/full-icu" \
+    WEB_SERVER_HOST="0.0.0.0" \
+    WEB_SERVER_PORT="3000"
 USER root
 # Copying in source code
 COPY . /tmp/src

--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ visar fyra komplexa matriser med miljöinformation.
 2. Backa upp utvecklingsdatabasen, `cp -v ./tmp/konfigurator.db ./tmp/pre-migrate-backup.db`
 3. Inför ändringarna i de entiteter som ska uppdateras och auto-generera en databas-migration:
    ```bash
-   npx ts-node ./node_modules/typeorm/cli.js migration:generate --name NamnPaNyMigration
+   npx ts-node ./node_modules/typeorm/cli.js migration:generate --name NamnPaNyMigr
    npm run format
    ```
-5. Öppna `./src/migrations/<langt timestamp>-NamnPaNyMigration.ts` och granska/städa upp innehållet
+5. Öppna `./src/migrations/<langt timestamp>-NamnPaNyMigr.ts` och granska/städa upp innehållet
 6. Starta appen i development-läge igen och testa igenom, kör igenom enhets- och _end-2-end_-testerna, o.s.v.
 7. Sälj in en vacker PR
 
@@ -118,6 +118,8 @@ $ docker-compose up -d konfigurator
 ### `v0.4.0` - Databasmigrering och uppstädade modeller
 
 - Stöd för databas-migrationer via TypeORM och en README-instruktion för hur de skapas
+- Användargränssnitt uppdaterat för att dölja tilltänkt framtida funktionalitet
+- Miljööversikt uppdaterad med stöd för att uppdatera fritextkommentar om miljöstatus
 
 ### `v0.3.0` – Grundläggande säkerhet med autentiseringskrav
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - .env.production
     environment:
       - DATABASE_URL=/data/konfigurator.db
-      - OAUTH2_CALLBACK_URL=https://konfigurator.mkdevops.se/callback
+      - OAUTH2_CALLBACK_URL=https://konfigurator.mkdevops.se/auth0-oauth2-callback
       - OAUTH2_LOCAL_ACCESS_TOKEN=/tmp/access_token.txt
     ports:
       - "3000:3000"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "konfigurator",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "konfigurator",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "NestJS-baserad webbtjänst för att konfigurera OpenShift-miljöer",
   "author": "mblomdahl",
   "homepage": "https://github.com/mkdevops-se/konfigurator",
@@ -40,6 +40,7 @@
     "connect-flash": "^0.1.1",
     "express-handlebars": "^5.2.1",
     "express-session": "^1.17.1",
+    "full-icu": "^1.3.4",
     "hbs": "^4.1.1",
     "joi": "^17.4.0",
     "jsonwebtoken": "^8.5.1",

--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -40,7 +40,7 @@ describe('AppController', () => {
       expect(await appController.getOverview({})).toMatchObject({
         user: undefined,
         title: 'Miljööversikt',
-        message: `Aktuell status: Miljöinformation visas baserat på senast inläst innehåll i databasen, klicka på "↻"-knapparna för att uppdatera.`,
+        message: `Aktuell status: Miljöinformation visas baserat på senast inläst innehåll i databasen.`,
         processEnv: {
           SERVER_STARTUP_TIMESTAMP: process.env.SERVER_STARTUP_TIMESTAMP,
           IMAGE_TAG: process.env.IMAGE_TAG,

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -55,7 +55,9 @@ export class AppController {
     return {
       user: req.user,
       title: 'Miljööversikt',
-      message: `Aktuell status: Miljöinformation visas baserat på senast inläst innehåll i databasen, klicka på "↻"-knapparna för att uppdatera.`,
+      message: `Aktuell status: Miljöinformation visas baserat på senast inläst innehåll i databasen${
+        req.user ? ', klicka på "↻"-knapparna för att uppdatera' : ''
+      }.`,
       processEnv: this.processEnv,
       environments,
     };

--- a/src/environments/dto/update-environment-comment.dto.ts
+++ b/src/environments/dto/update-environment-comment.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class UpdateEnvironmentCommentDto {
+  @IsString()
+  comment: string;
+}

--- a/src/environments/entities/environment.entity.ts
+++ b/src/environments/entities/environment.entity.ts
@@ -94,6 +94,12 @@ export class Environment {
   })
   comment?: string;
 
+  @Column({
+    type: 'varying character',
+    nullable: true,
+  })
+  comment_origin?: string;
+
   @CreateDateColumn({ select: false })
   created_at?: Date;
 

--- a/src/environments/environments.controller.ts
+++ b/src/environments/environments.controller.ts
@@ -7,12 +7,17 @@ import {
   Param,
   Post,
   Put,
+  Redirect,
+  Req,
   UseFilters,
 } from '@nestjs/common';
+import { RedirectResponse } from '@nestjs/core/router/router-response-controller';
+import { Request } from 'express';
 import { HttpExceptionFilter } from '../common/filters/http-exception.filter';
 import { ValidationPipe } from '../common/pipes/validation.pipe';
 import { CreateEnvironmentDto } from './dto/create-environment.dto';
 import { UpdateEnvironmentDto } from './dto/update-environment.dto';
+import { UpdateEnvironmentCommentDto } from './dto/update-environment-comment.dto';
 import { EnvironmentsService } from './environments.service';
 import { Environment } from './entities/environment.entity';
 import { Public } from '../common/guards/authenticated.guard';
@@ -75,6 +80,36 @@ export class EnvironmentsController {
     );
     this.logger.debug(`Updated environment: ${JSON.stringify(updatedEnv)}`);
     return updatedEnv;
+  }
+
+  @Post(':name/comment')
+  @Redirect()
+  async createComment(
+    @Param('name') name: string,
+    @Body(new ValidationPipe())
+    updateEnvCommentDto: UpdateEnvironmentCommentDto,
+    @Req() req: Request,
+  ): Promise<Environment | RedirectResponse> {
+    updateEnvCommentDto.comment = updateEnvCommentDto.comment || null;
+    this.logger.log(
+      `Updating environment ${name} with ${JSON.stringify(
+        updateEnvCommentDto,
+      )} by ${req.user.user_id} ...`,
+    );
+    const localTimestamp = `${new Date().toLocaleString('sv-SE')}`;
+    const { updated_at, ...updatedEnv } = await this.environmentsService.update(
+      name,
+      {
+        ...updateEnvCommentDto,
+        comment_origin: `${req.user.user_id}, ${localTimestamp}`,
+      },
+    );
+    this.logger.debug(`Updated environment: ${JSON.stringify(updatedEnv)}`);
+    if (req.headers.referer) {
+      return { statusCode: 302, url: req.headers.referer };
+    } else {
+      return updatedEnv;
+    }
   }
 
   @Delete(':name')

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,16 @@ declare global {
   }
 }
 
+const hasFullICU = () => {
+  try {
+    const january = new Date(9e8);
+    const spanish = new Intl.DateTimeFormat('es', { month: 'long' });
+    return spanish.format(january) === 'enero';
+  } catch (err) {
+    return false;
+  }
+};
+
 async function bootstrap() {
   process.env.SERVER_STARTUP_TIMESTAMP = new Date()
     .toISOString()
@@ -39,6 +49,10 @@ async function bootstrap() {
   app.use(passport.initialize());
   app.use(passport.session());
   app.use(flash());
+
+  if (!hasFullICU()) {
+    throw Error('ICU Check Failed');
+  }
 
   await app.listen(
     +configService.get<string>('WEB_SERVER_PORT'),

--- a/src/migrations/1617885846157-AddEnvCommentOrigin.ts
+++ b/src/migrations/1617885846157-AddEnvCommentOrigin.ts
@@ -1,0 +1,110 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddEnvCommentOrigin1617885846157 implements MigrationInterface {
+  name = 'AddEnvCommentOrigin1617885846157';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "temporary_environment"
+       (
+         "name"                     varying character PRIMARY KEY NOT NULL,
+         "rank"                     integer                       NOT NULL DEFAULT (0),
+         "ocp_tenant_domain"        varying character             NOT NULL,
+         "ocp_namespace_front"      varying character             NOT NULL,
+         "ocp_namespace_backend"    varying character             NOT NULL,
+         "ocp_namespace_restricted" varying character             NOT NULL,
+         "ocp_namespace_public"     varying character,
+         "mq_url"                   varying character,
+         "mq_namespace"             varying character,
+         "db_url"                   varying character,
+         "default_spring_profiles"  varying character,
+         "login_url"                varying character,
+         "gateway_url"              varying character,
+         "comment"                  varying character,
+         "comment_origin"           varying character,
+         "created_at"               datetime                      NOT NULL DEFAULT (datetime('now')),
+         "updated_at"               datetime                      NOT NULL DEFAULT (datetime('now'))
+       )`,
+    );
+    await queryRunner.query(
+      `INSERT INTO "temporary_environment"("name", "rank", "ocp_tenant_domain", "ocp_namespace_front",
+                                           "ocp_namespace_backend", "ocp_namespace_restricted", "ocp_namespace_public",
+                                           "mq_url", "mq_namespace", "db_url", "default_spring_profiles", "login_url",
+                                           "gateway_url", "comment", "created_at", "updated_at")
+       SELECT "name",
+              "rank",
+              "ocp_tenant_domain",
+              "ocp_namespace_front",
+              "ocp_namespace_backend",
+              "ocp_namespace_restricted",
+              "ocp_namespace_public",
+              "mq_url",
+              "mq_namespace",
+              "db_url",
+              "default_spring_profiles",
+              "login_url",
+              "gateway_url",
+              "comment",
+              "created_at",
+              "updated_at"
+       FROM "environment"`,
+    );
+    await queryRunner.query(`DROP TABLE "environment"`);
+    await queryRunner.query(
+      `ALTER TABLE "temporary_environment"
+        RENAME TO "environment"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "environment"
+        RENAME TO "temporary_environment"`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "environment"
+       (
+         "name"                     varying character PRIMARY KEY NOT NULL,
+         "rank"                     integer                       NOT NULL DEFAULT (0),
+         "ocp_tenant_domain"        varying character             NOT NULL,
+         "ocp_namespace_front"      varying character             NOT NULL,
+         "ocp_namespace_backend"    varying character             NOT NULL,
+         "ocp_namespace_restricted" varying character             NOT NULL,
+         "ocp_namespace_public"     varying character,
+         "mq_url"                   varying character,
+         "mq_namespace"             varying character,
+         "db_url"                   varying character,
+         "default_spring_profiles"  varying character,
+         "login_url"                varying character,
+         "gateway_url"              varying character,
+         "comment"                  varying character,
+         "created_at"               datetime                      NOT NULL DEFAULT (datetime('now')),
+         "updated_at"               datetime                      NOT NULL DEFAULT (datetime('now'))
+       )`,
+    );
+    await queryRunner.query(
+      `INSERT INTO "environment"("name", "rank", "ocp_tenant_domain", "ocp_namespace_front", "ocp_namespace_backend",
+                                 "ocp_namespace_restricted", "ocp_namespace_public", "mq_url", "mq_namespace", "db_url",
+                                 "default_spring_profiles", "login_url", "gateway_url", "comment", "created_at",
+                                 "updated_at")
+       SELECT "name",
+              "rank",
+              "ocp_tenant_domain",
+              "ocp_namespace_front",
+              "ocp_namespace_backend",
+              "ocp_namespace_restricted",
+              "ocp_namespace_public",
+              "mq_url",
+              "mq_namespace",
+              "db_url",
+              "default_spring_profiles",
+              "login_url",
+              "gateway_url",
+              "comment",
+              "created_at",
+              "updated_at"
+       FROM "temporary_environment"`,
+    );
+    await queryRunner.query(`DROP TABLE "temporary_environment"`);
+  }
+}

--- a/test/environments.e2e-spec.ts
+++ b/test/environments.e2e-spec.ts
@@ -55,6 +55,7 @@ describe('EnvironmentsController (e2e)', () => {
           login_url: null,
           gateway_url: null,
           comment: null,
+          comment_origin: null,
         });
     });
 
@@ -124,6 +125,7 @@ describe('EnvironmentsController (e2e)', () => {
           login_url: null,
           gateway_url: null,
           comment: null,
+          comment_origin: null,
         });
     });
 
@@ -153,6 +155,7 @@ describe('EnvironmentsController (e2e)', () => {
             login_url: null,
             gateway_url: null,
             comment: null,
+            comment_origin: null,
           },
         ]);
     });
@@ -186,6 +189,7 @@ describe('EnvironmentsController (e2e)', () => {
           login_url: 'https://honeypots-for-free.dot.com',
           gateway_url: 'https://the-gateway-takes-you-there.travel',
           comment: 'Mats was here',
+          comment_origin: null,
         });
     });
 
@@ -250,6 +254,7 @@ describe('EnvironmentsController (e2e)', () => {
           login_url: 'https://honeypots-for-free.dot.com',
           gateway_url: 'https://the-gateway-takes-you-there.travel',
           comment: 'Mats was here',
+          comment_origin: null,
         });
     });
 

--- a/views/overview.hbs
+++ b/views/overview.hbs
@@ -18,7 +18,16 @@
     / Gateway URL: <a href="{{ this.gateway_url }}">{{ this.gateway_url }}</a><br/>
   </p>
   <p>
-    Comment: {{#if this.comment }}{{ this.comment }}{{else}}N/A{{/if}}
+    {{#if @root.user }}
+    <form method="post" action="/environments/{{ this.name }}/comment">
+      Kommentar, miljöstatus ({{ this.comment_origin }}):
+      <br><textarea name="comment" cols="120" rows="3">{{ this.comment }}</textarea>
+      <br><input type="submit" value="Uppdatera">
+    </form>
+    {{else}}
+    Kommentar, miljöstatus ({{ this.comment_origin }}):
+    {{#if this.comment }}<br><textarea readonly cols="120" rows="3">{{ this.comment }}</textarea>{{else}}N/A{{/if}}
+    {{/if}}
   </p>
   <table border="1px" cellspacing="2px" cellpadding="4px">
     <thead>
@@ -41,9 +50,11 @@
           <thead>
           <tr>
             <th rowspan="2">Deployment</th>
+            {{#if @root.user }}
             <th colspan="2">Memory</th>
             <th colspan="2">CPU</th>
             <th colspan="2">Replicas/Pods</th>
+            {{/if}}
             <th rowspan="2">Spring Profiles</th>
             <th rowspan="2">Current Image</th>
             <th rowspan="2">Build Timestamp</th>
@@ -53,12 +64,14 @@
             {{/if}}
           </tr>
           <tr>
+            {{#if @root.user }}
             <td>Min</td>
             <td>Max</td>
             <td>Min</td>
             <td>Max</td>
             <td>Target</td>
             <td>Current</td>
+            {{/if}}
             {{#if @root.user }}
             <td>
               <form method="post" action="/tasks/bulk">
@@ -76,12 +89,14 @@
           {{#each this.deployments }}
           <tr id="{{ this.ocp_namespace }}/{{ this.name }}">
             <td><pre>{{ this.name }}<sup>{{#if this.external_url }}{{#if this.is_gateway }}†{{/if}}<a href="{{ this.external_url }}" target="_blank">→</a>{{else}}<small>N/A</small>{{/if}}</sup></pre></td>
+            {{#if @root.user }}
             <td>{{#if this.memory_min }}<pre>{{ this.memory_min }}</pre>{{else}}<small>N/A</small>{{/if}}</td>
             <td>{{#if this.memory_max }}<pre>{{ this.memory_max }}</pre>{{else}}<small>N/A</small>{{/if}}</td>
             <td>{{#if this.cpu_min }}<pre>{{ this.cpu_min }}</pre>{{else}}<small>N/A</small>{{/if}}</td>
             <td>{{#if this.cpu_max }}<pre>{{ this.cpu_max }}</pre>{{else}}<small>N/A</small>{{/if}}</td>
             <td>{{#if this.replicas_target }}<pre>{{ this.replicas_target }}</pre>{{else}}<small>N/A</small>{{/if}}</td>
             <td>{{#if this.replicas_current }}<pre>{{ this.replicas_current }}</pre>{{else}}<small>N/A</small>{{/if}}</td>
+            {{/if}}
             <td>{{#if this.spring_profiles_active }}<pre>{{ this.spring_profiles_active }}</pre>{{else}}<small>N/A</small>{{/if}}</td>
             <td>{{#if this.image_tag }}<pre><a href="/builds#{{ this.name }}-{{ this.image_tag }}">{{ this.image_tag }}</a></pre>{{else}}<small>N/A</small>{{/if}}</td>
             <td>{{#if this.build_timestamp }}<pre>{{ this.build_timestamp }}</pre>{{else}}<small>N/A</small>{{/if}}</td>


### PR DESCRIPTION
## Description

- Environment comment now editable by an authenticated user
- Memory-CPU-Replicas/Pods columns hidden from view for unauthenticated users
- First real database migration utilizing #4 added as `AddEnvCommentOrigin1617885846157`
- ICU dependency added; now the server supports generating timestamp strings with Swedish locale

Resolves #31.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

 - [ ] Manual testing on macOS (and a little bit on Windows)
 - [ ] Automated unit and end-2-end tests still pass
