### PR TITLE
Add Links to Kibana Error Log Archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ $ docker-compose up -d konfigurator
   - Multipla inloggning-URL:er
   - Stöd för att dölja en miljö från översiktssidan
 - _`Deployment`_-entiteten uppdaterad med ett nytt `build_info_api_path`-attribut som defaultar till `/bygginfo`
+- Översiktssidan med miljöinformation kompletterad med länkar till loggarkivet (för inloggade användare)
 
 ### `v0.4.0` – Databasmigrering och uppstädade modeller
 

--- a/src/deployments/deployments.controller.ts
+++ b/src/deployments/deployments.controller.ts
@@ -7,8 +7,10 @@ import {
   Param,
   Post,
   Put,
+  Res,
   UseFilters,
 } from '@nestjs/common';
+import { Response } from 'express';
 import { HttpExceptionFilter } from '../common/filters/http-exception.filter';
 import { ValidationPipe } from '../common/pipes/validation.pipe';
 import { DeploymentsService } from './deployments.service';
@@ -62,6 +64,29 @@ export class DeploymentsController {
     );
     this.logger.debug(`Got one deployment: ${JSON.stringify(oneDeploy)}`);
     return oneDeploy;
+  }
+
+  @Public()
+  @Get(':environment/deployments/:name/error_logs_redirect')
+  async errorLogsRedirect(
+    @Param('environment') environment: string,
+    @Param('name') name: string,
+    @Res() res: Response,
+  ): Promise<void> {
+    this.logger.log(
+      `Constructing log archive URL for deployment ${name} in environment ${environment} ...`,
+    );
+    const logArchiveErrorLogsUrl = await this.deploymentsService.getLogArchiveErrorLogsUrl(
+      environment,
+      null,
+      name,
+    );
+
+    this.logger.debug(
+      `Got log archive error logs URL: ${logArchiveErrorLogsUrl}`,
+    );
+
+    res.redirect(logArchiveErrorLogsUrl);
   }
 
   @Public()

--- a/src/deployments/deployments.service.spec.ts
+++ b/src/deployments/deployments.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AppModule } from '../app.module';
+import { EnvironmentsModule } from '../environments/environments.module';
 import { DeploymentsModule } from './deployments.module';
 import { DeploymentsService } from './deployments.service';
 import { DeploymentRepository } from './entities/deployment.repository';
@@ -9,7 +10,7 @@ describe('DeploymentsService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [AppModule, DeploymentsModule],
+      imports: [AppModule, EnvironmentsModule, DeploymentsModule],
       providers: [DeploymentsService, DeploymentRepository],
     }).compile();
 

--- a/src/deployments/deployments.service.ts
+++ b/src/deployments/deployments.service.ts
@@ -1,16 +1,83 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { EnvironmentInterface } from '../interfaces/environment.interface';
 import { DeploymentInterface } from '../interfaces/deployment.interface';
+import { EnvironmentsService } from '../environments/environments.service';
 import { DeploymentRepository } from './entities/deployment.repository';
 import { Deployment } from './entities/deployment.entity';
 import { CreateDeploymentDto } from './dto/create-deployment.dto';
 import { UpdateDeploymentDto } from './dto/update-deployment.dto';
 
+const formatKibanaErrorLogsUrl = (
+  ocp_tenant_domain: string,
+  kibana_index: string,
+  deployment_name: string,
+) => {
+  return `https://kibana.${ocp_tenant_domain}/app/kibana#/discover?_g=(time:(from:now-1w,mode:relative,to:now))&_a=(columns:!(_source),filters:!(('%24state':(store:appState),meta:(alias:!n,disabled:!f,index:'project.${kibana_index}.*',key:level,negate:!f,params:!(warning,err),type:phrases,value:\\'warning,%20err\\'),query:(bool:(minimum_should_match:1,should:!((match_phrase:(level:warning)),(match_phrase:(level:err)))))),('%24state':(store:appState),meta:(alias:!n,disabled:!f,index:'project.${kibana_index}.*',key:kubernetes.container_name.raw,negate:!f,type:phrase,value:${deployment_name}),query:(match:(kubernetes.container_name.raw:(query:${deployment_name},type:phrase))))),index:'project.${kibana_index}.*',interval:auto,query:(match_all:()),sort:!('@timestamp',desc))`;
+};
+
+const getLogArchiveIndexForDeployment = (
+  environment: EnvironmentInterface,
+  deployment: DeploymentInterface,
+) => {
+  switch (deployment.ocp_namespace) {
+    case environment.ocp_namespace_front:
+      return environment.log_archive_index_front;
+    case environment.ocp_namespace_backend:
+      return environment.log_archive_index_backend;
+    case environment.ocp_namespace_restricted:
+      return environment.log_archive_index_restricted;
+    case environment.ocp_namespace_public:
+      return environment.log_archive_index_public;
+    default:
+      return null;
+  }
+};
+
+const getLogArchiveIndexForDeploymentOrFail = (
+  environment: EnvironmentInterface,
+  deployment: DeploymentInterface,
+) => {
+  const logArchiveIndex = getLogArchiveIndexForDeployment(
+    environment,
+    deployment,
+  );
+  if (!logArchiveIndex) {
+    throw new NotFoundException(
+      `There's no log archive index matching ocp_namespace ${deployment.ocp_namespace}`,
+    );
+  }
+  return logArchiveIndex;
+};
+
 @Injectable()
 export class DeploymentsService {
   private readonly logger = new Logger(DeploymentsService.name);
 
-  constructor(private deploymentsRepository: DeploymentRepository) {}
+  constructor(
+    private deploymentsRepository: DeploymentRepository,
+    private environmentsService: EnvironmentsService,
+  ) {}
+
+  async getLogArchiveErrorLogsUrl(
+    environment_name: string | null,
+    ocp_namespace: string | null,
+    name: string,
+  ): Promise<string> {
+    const deployment = await this.deploymentsRepository.findEntity(
+      environment_name,
+      ocp_namespace,
+      name,
+    );
+    const environment = await this.environmentsService.getOne(
+      deployment.environment,
+    );
+
+    return formatKibanaErrorLogsUrl(
+      environment.ocp_tenant_domain,
+      getLogArchiveIndexForDeploymentOrFail(environment, deployment),
+      deployment.name,
+    );
+  }
 
   async create(environment: string, deployment: CreateDeploymentDto) {
     return await this.deploymentsRepository.insertEntity({
@@ -63,6 +130,10 @@ export class DeploymentsService {
     for (const deployment of deployments) {
       if (deployment.is_gateway) {
         deployment.external_url = `https://${deployment.name}-${deployment.ocp_namespace}.${environment.ocp_tenant_domain}`;
+      }
+
+      if (getLogArchiveIndexForDeployment(environment, deployment)) {
+        deployment.error_logs_redirect_url = `/environments/${environment.name}/deployments/${deployment.name}/error_logs_redirect`;
       }
     }
 

--- a/src/interfaces/deployment.interface.ts
+++ b/src/interfaces/deployment.interface.ts
@@ -3,6 +3,7 @@ export interface DeploymentInterface {
   ocp_namespace: string;
   name: string;
   is_gateway: boolean;
+  error_logs_redirect_url?: string;
   external_url?: string;
   memory_min?: string;
   memory_max?: string;

--- a/views/overview.hbs
+++ b/views/overview.hbs
@@ -54,6 +54,7 @@
             <th colspan="2">Memory</th>
             <th colspan="2">CPU</th>
             <th colspan="2">Replicas/Pods</th>
+            <th rowspan="2">Logs</th>
             {{/if}}
             <th rowspan="2">Spring Profiles</th>
             <th rowspan="2">Current Image</th>
@@ -96,6 +97,7 @@
             <td>{{#if this.cpu_max }}<pre>{{ this.cpu_max }}</pre>{{else}}<small>N/A</small>{{/if}}</td>
             <td>{{#if this.replicas_target }}<pre>{{ this.replicas_target }}</pre>{{else}}<small>N/A</small>{{/if}}</td>
             <td>{{#if this.replicas_current }}<pre>{{ this.replicas_current }}</pre>{{else}}<small>N/A</small>{{/if}}</td>
+            <td>{{#if this.error_logs_redirect_url }}<pre><a href="{{ this.error_logs_redirect_url }}" target="_blank">err</a></pre>{{else}}<small>N/A</small>{{/if}}</td>
             {{/if}}
             <td>{{#if this.spring_profiles_active }}<pre>{{ this.spring_profiles_active }}</pre>{{else}}<small>N/A</small>{{/if}}</td>
             <td>{{#if this.image_tag }}<pre><a href="/builds#{{ this.name }}-{{ this.image_tag }}">{{ this.image_tag }}</a></pre>{{else}}<small>N/A</small>{{/if}}</td>


### PR DESCRIPTION
## Description

New things:
- "Logs" column added to the deployments in _Environments Overview_ grids (for authenticated users only)
- New public `GET /environments/:env_name/deployments/:name/error_logs_redirect` API added to get redirects to error logs

Tests:
- End-2-end test for successful redirect response when all pre-requisites are satisfied
- End-2-end test for failing redirect due to lack on environment data

Fixes #36

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

 - [x] Manual testing locally
 - [x] 2 new end-2-end tests added
